### PR TITLE
doc: add space to doc title

### DIFF
--- a/docs/pages/index.qmd
+++ b/docs/pages/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: The `bit`Library
+title: The `bit` Library
 ---
 
 ## Introduction


### PR DESCRIPTION
when viewed in a browser, the browser tab says:
> The bitLibrary - Bit Space/GF(2)
    
the page title renders as:
> The `bit`Library